### PR TITLE
fix(action): escape special characters from the prompt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,12 +58,6 @@ jobs:
             echo "The time is now $(date +%T)"
             ```
 
-            ## Code block
-            
-            ```python
-            print("Hello, world!")
-            ```
-
       - name: Print response 3
         shell: bash
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,20 @@ jobs:
         with:
           model: tinyllama
           prompt: |
+            # Markdown example
+
             A markdown example with backticks:
 
             ```bash
-            echo "Hello, world!"
+            echo "The time is now $(date +%T)"
             ```
+
+            ## Code block
             
+            ```python
+            print("Hello, world!")
+            ```
+
       - name: Print response 3
         shell: bash
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,21 @@ jobs:
         env:
           response: ${{ steps.response-2.outputs.response }}
         run: echo "$response"
+
+      - name: Run action
+        id: response-3
+        uses: ./
+        with:
+          model: tinyllama
+          prompt: |
+            A markdown example with backticks:
+
+            ```bash
+            echo "Hello, world!"
+            ```
+            
+      - name: Print response 3
+        shell: bash
+        env:
+          response: ${{ steps.response-3.outputs.response }}
+        run: echo "$response"

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         EOF=EOF_OLLAMA_$(openssl rand -hex 12)
         {
           echo "response<<$EOF"
-          ollama run $MODEL "$PROMPT"
+          ollama run $MODEL "${PROMPT@Q}"
           echo $EOF
         } >> $GITHUB_OUTPUT
       env:

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         EOF=EOF_OLLAMA_$(openssl rand -hex 12)
         {
           echo "response<<$EOF"
-          ollama run $MODEL "${PROMPT@Q}"
+          ollama run $MODEL "$(printf '%q' $PROMPT)"
           echo $EOF
         } >> $GITHUB_OUTPUT
       env:


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

The action fails when you include special characters in your prompt.

## What is the current behavior?

The action fails when you include special characters in your prompt.

## What is the new behavior?

The prompt is escaped so that this doesn't happen.

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [ ] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation

<!--
Any other comments? Thank you for contributing!
-->
