### PR TITLE
fix(action): add if conditional for version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,11 @@ runs:
   using: composite
   steps:
     - name: Setup Ollama
+      if: ${{ !inputs.version }}
+      uses: ai-action/setup-ollama@v1
+
+    - name: Setup Ollama v${{ inputs.version }}
+      if: inputs.version
       uses: ai-action/setup-ollama@v1
       with:
         version: ${{ inputs.version }}


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(action): add if conditional for version

Fixes #8

## What is the current behavior?

When optional `version` is not set:

```
Error: versionSpec parameter is required
```

## What is the new behavior?

Uses latest ollama version when version is not set

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation